### PR TITLE
Small "parallel-flag" modification

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Example:
 
 ```julia
 using MultistartOptimization, NLopt
-P = MinimizationProblem(x -> sum(abs2, x), -ones(10), ones(10))
+#P = MinimizationProblem(x -> sum(abs2, x), -ones(10), ones(10))
+P = MinimizationProblem(x -> sum.(map.(abs2, x)), -ones(10), ones(10))
 local_method = NLoptLocalMethod(NLopt.LN_BOBYQA)
 multistart_method = TikTak(100)
 p = multistart_minimization(multistart_method, local_method, P)

--- a/src/MultistartOptimization.jl
+++ b/src/MultistartOptimization.jl
@@ -182,6 +182,7 @@ function multistart_minimization(multistart_method::TikTak, local_method,
     @unpack quasirandom_N, initial_N, θ_min, θ_max, θ_pow = multistart_method
     quasirandom_points = sobol_starting_points(minimization_problem, quasirandom_N)
     initial_points = _keep_lowest(quasirandom_points, initial_N)
+    print("hellow cow")
     function _step(visited_minimum, (i, initial_point))
         θ = _weight_parameter(multistart_method, i)
         x = @. (1 - θ) * initial_point.location + θ * visited_minimum.location

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,17 +1,16 @@
 using MultistartOptimization
 using Test
 using NLopt: NLopt
-
+using Distributed
 using MultistartOptimization: local_minimization
 
 include("test_functions.jl")
 
 @testset "test function sanity checks" begin
     for F in TEST_FUNCTIONS
-        @test F(minimum_location(F, 10)) ≈ 0
+        @test F([minimum_location(F, 10)])[1] ≈ 0
     end
 end
-
 @testset "global optimization" begin
     for F in setdiff(TEST_FUNCTIONS, (RASTRIGIN, )) # Rastrigin disabled for now
         n = 10
@@ -21,6 +20,6 @@ end
         p = multistart_minimization(multistart_method, local_method, P)
         x₀ = minimum_location(F, n)
         @test p.location ≈ x₀ atol = 1e-5
-        @test p.value ≈ F(x₀) atol = 1e-10
+        @test p.value ≈ F([x₀])[1] atol = 1e-10
     end
 end


### PR DESCRIPTION
This version suggests the incorporation of a flag "enable_parallel" to enable/disable the implicit parallel evaluation of the points generated through a low discrepancy sequence method (e.g. Sobol). The latter allows to the user to put in parallel in different layers.  